### PR TITLE
Fix issues with build engine

### DIFF
--- a/src/Trt.cpp
+++ b/src/Trt.cpp
@@ -242,9 +242,9 @@ void Trt::BuildEngine(
 #endif
     assert(mEngine != nullptr && "build trt engine failed");
     SaveEngine(engineFile, plan);
-    CreateDeviceBuffer();
     mContext.reset(mEngine->createExecutionContext());
     assert(mContext != nullptr);
+    CreateDeviceBuffer();
     mBuilder.reset(nullptr);
     mConfig.reset(nullptr);
 }

--- a/src/Trt.cpp
+++ b/src/Trt.cpp
@@ -175,6 +175,7 @@ void Trt::AddDynamicShapeProfile(const std::string& inputName,
     mProfile->setDimensions(inputName.c_str(), nvinfer1::OptProfileSelector::kMIN, minDim);
     mProfile->setDimensions(inputName.c_str(), nvinfer1::OptProfileSelector::kOPT, optDim);
     mProfile->setDimensions(inputName.c_str(), nvinfer1::OptProfileSelector::kMAX, maxDim);
+    mConfig->addOptimizationProfile(mProfile);
 }
 
 void Trt::BuildEngine(


### PR DESCRIPTION
This PR fixes 2 issues that was causing the BuildEnigne() function to fail
1 - AddDynamicShapeProfile() function was missing adding the optimization profile to build config
2 -in BuildEgnie() function CreateDeviceBuffer() was called before initializing the mContext which was null pointer. 

Hope that this pull request was helpful.