### PR TITLE
feat: target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${CUDA_gencode_flags}")
 
 include_directories(third_party/spdlog/include)
 include_directories(third_party/pybind11/include)
-include_directories(./)
 include_directories(./src)
 include_directories(./plugin)
 include_directories(${ZLIB_INCLUDE_DIRS})
@@ -84,6 +83,7 @@ file(GLOB_RECURSE trt_source
      plugin/*.cpp
      )
 cuda_add_library(tinytrt SHARED ${trt_source})
+target_include_directories(tinytrt PUBLIC ./)
 target_compile_options(tinytrt PUBLIC -std=c++11 -Wall -Wno-deprecated -Wfloat-conversion)
 set_target_properties(tinytrt PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(tinytrt PROPERTIES VERSION ${PROJECT_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ file(GLOB_RECURSE trt_source
      )
 cuda_add_library(tinytrt SHARED ${trt_source})
 target_include_directories(tinytrt PUBLIC ./)
+target_link_libraries(tinytrt ${LIBNVINFER} ${LIBNVINFER_PLUGIN} ${LIBNVPARSERS} ${LIBNVONNXPARSER} ${ZLIB_LIBRARIES})
 target_compile_options(tinytrt PUBLIC -std=c++11 -Wall -Wno-deprecated -Wfloat-conversion)
 set_target_properties(tinytrt PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(tinytrt PROPERTIES VERSION ${PROJECT_VERSION})


### PR DESCRIPTION
Add `target_include_directories` to `CMakeLists.txt` so that `Trt.h` can be automatically added to include path when `tinytrt` be in `target_link_libraries`

在 `CMakeLists.txt` 中使用 `target_include_directories` 来 include 根目录，这样使用 `target_link_libraries` 链接到 `tinytrt` 时会自动将（含有 `Trt.h` 的）根目录加入到 include，方便将本库作为子模块使用。